### PR TITLE
echo the value of DISTRO to file

### DIFF
--- a/scripts/beakerCheckOut.sh
+++ b/scripts/beakerCheckOut.sh
@@ -297,6 +297,7 @@ echo $JOB_HOSTNAME > hostname
 
 DISTRO=`xmlstarlet sel -t --value-of "//recipe/@distro" job-result`
 echo $DISTRO
+echo $DISTRO > distro
 
 TASKS=$(echo $TASKS | sed -e s/--task=//g)
 for TASK in $TASKS; do


### PR DESCRIPTION
echoing the value of DISTRO to file will allow Jenkins jobs to grab the DISTRO value in the same way that the hostname of the beaker provisioned system is grabbed 
